### PR TITLE
[gh-11] Add RDS module

### DIFF
--- a/core/locals.tf
+++ b/core/locals.tf
@@ -2,5 +2,4 @@ locals {
   app_name           = "devops-ic"
   region             = "ap-southeast-1"
   namespace          = "${local.app_name}-${var.environment}"
-  rds_instance_class = "db.t3.micro"
 }

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  app_name           = "devops_ic"
+  app_name           = "devops-ic"
   region             = "ap-southeast-1"
   namespace          = "${local.app_name}-${var.environment}"
   rds_instance_class = "db.t3.micro"

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  app_name  = "devops_ic"
-  region    = "ap-southeast-1"
-  namespace = "${local.app_name}-${var.environment}"
+  app_name           = "devops_ic"
+  region             = "ap-southeast-1"
+  namespace          = "${local.app_name}-${var.environment}"
+  rds_instance_class = "db.t3.micro"
 }

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  app_name           = "devops-ic"
-  region             = "ap-southeast-1"
-  namespace          = "${local.app_name}-${var.environment}"
+  app_name  = "devops-ic"
+  region    = "ap-southeast-1"
+  namespace = "${local.app_name}-${var.environment}"
 }

--- a/core/main.tf
+++ b/core/main.tf
@@ -18,3 +18,22 @@ module "cloudwatch" {
 
   namespace = local.namespace
 }
+
+module "rds" {
+  source = "../modules/rds"
+
+  env_namespace = local.namespace
+
+  vpc_security_group_ids = module.sercurity_group.vpc_security_group_ids
+  vpc_id                 = module.vpc.vpc_id
+
+  subnets = module.vpc.private_subnet_ids
+
+  instance_class = local.rds_instance_class
+  database_name  = var.rds_database_name
+  username       = var.rds_username
+  password       = var.rds_password
+
+  autoscaling_min_capacity = var.rds_autoscaling_min_capacity
+  autoscaling_max_capacity = var.rds_autoscaling_max_capacity
+}

--- a/core/main.tf
+++ b/core/main.tf
@@ -7,7 +7,7 @@ module "vpc" {
 module "ssm" {
   source = "../modules/ssm"
 
-  env_namespace = local.namespace
+  namespace = local.namespace
   secrets = {
     secret_key_base = var.secret_key_base
   }
@@ -22,7 +22,7 @@ module "cloudwatch" {
 module "rds" {
   source = "../modules/rds"
 
-  env_namespace = local.namespace
+  namespace = local.namespace
 
   vpc_security_group_ids = module.sercurity_group.rds_security_groups_ids
   vpc_id                 = module.vpc.vpc_id

--- a/core/main.tf
+++ b/core/main.tf
@@ -29,10 +29,9 @@ module "rds" {
 
   subnets = module.vpc.private_subnets
 
-  instance_class = local.rds_instance_class
-  database_name  = var.rds_database_name
-  username       = var.rds_username
-  password       = var.rds_password
+  database_name = var.rds_database_name
+  username      = var.rds_username
+  password      = var.rds_password
 }
 
 module "security_group" {

--- a/core/main.tf
+++ b/core/main.tf
@@ -24,7 +24,7 @@ module "rds" {
 
   namespace = local.namespace
 
-  vpc_security_group_ids = module.sercurity_group.rds_security_groups_ids
+  vpc_security_group_ids = module.security_group.rds_security_groups_ids
   vpc_id                 = module.vpc.vpc_id
 
   subnets = module.vpc.private_subnets
@@ -38,7 +38,7 @@ module "rds" {
   autoscaling_max_capacity = var.rds_autoscaling_max_capacity
 }
 
-module "sercurity_group" {
+module "security_group" {
   source = "../modules/security_group"
 
   namespace = local.namespace

--- a/core/main.tf
+++ b/core/main.tf
@@ -24,10 +24,10 @@ module "rds" {
 
   env_namespace = local.namespace
 
-  vpc_security_group_ids = module.sercurity_group.vpc_security_group_ids
+  vpc_security_group_ids = module.sercurity_group.rds_security_groups_ids
   vpc_id                 = module.vpc.vpc_id
 
-  subnets = module.vpc.private_subnet_ids
+  subnets = module.vpc.private_subnets
 
   instance_class = local.rds_instance_class
   database_name  = var.rds_database_name
@@ -36,4 +36,11 @@ module "rds" {
 
   autoscaling_min_capacity = var.rds_autoscaling_min_capacity
   autoscaling_max_capacity = var.rds_autoscaling_max_capacity
+}
+
+module "sercurity_group" {
+  source = "../modules/security_group"
+
+  namespace = local.namespace
+  vpc_id    = module.vpc.vpc_id
 }

--- a/core/main.tf
+++ b/core/main.tf
@@ -33,9 +33,6 @@ module "rds" {
   database_name  = var.rds_database_name
   username       = var.rds_username
   password       = var.rds_password
-
-  autoscaling_min_capacity = var.rds_autoscaling_min_capacity
-  autoscaling_max_capacity = var.rds_autoscaling_max_capacity
 }
 
 module "security_group" {

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -39,14 +39,5 @@ variable "rds_username" {
 variable "rds_password" {
   description = "RDS password"
   type        = string
-}
-
-variable "rds_autoscaling_min_capacity" {
-  description = "Minimum number of RDS read replicas when autoscaling is enabled"
-  type        = number
-}
-
-variable "rds_autoscaling_max_capacity" {
-  description = "Maximum number of RDS read replicas when autoscaling is enabled"
-  type        = number
+  sensitive   = true
 }

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -25,3 +25,28 @@ variable "secret_key_base" {
   type        = string
   sensitive   = true
 }
+
+variable "rds_database_name" {
+  description = "RDS database name"
+  type        = string
+}
+
+variable "rds_username" {
+  description = "RDS username"
+  type        = string
+}
+
+variable "rds_password" {
+  description = "RDS password"
+  type        = string
+}
+
+variable "rds_autoscaling_min_capacity" {
+  description = "Minimum number of RDS read replicas when autoscaling is enabled"
+  type        = number
+}
+
+variable "rds_autoscaling_max_capacity" {
+  description = "Maximum number of RDS read replicas when autoscaling is enabled"
+  type        = number
+}

--- a/modules/rds/locals.tf
+++ b/modules/rds/locals.tf
@@ -1,4 +1,6 @@
 locals {
+  instance_class = "db.t3.micro"
+
   autoscaling_min_capacity = 0
   autoscaling_max_capacity = 0
 }

--- a/modules/rds/locals.tf
+++ b/modules/rds/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  autoscaling_min_capacity = 0
+  autoscaling_max_capacity = 0
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -17,8 +17,8 @@ module "rds" {
   }
 
   autoscaling_enabled      = true
-  autoscaling_min_capacity = var.autoscaling_min_capacity
-  autoscaling_max_capacity = var.autoscaling_max_capacity
+  autoscaling_min_capacity = local.autoscaling_min_capacity
+  autoscaling_max_capacity = local.autoscaling_max_capacity
 
   create_monitoring_role = false
   create_security_group  = false

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -11,7 +11,7 @@ module "rds" {
   subnets                = var.subnets
   vpc_security_group_ids = var.vpc_security_group_ids
 
-  instance_class = var.instance_class
+  instance_class = local.instance_class
   instances = {
     one = {}
   }

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,35 @@
+module "rds" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "9.0.0"
+
+  name = "${var.env_namespace}-aurora-db"
+
+  engine         = "aurora-postgresql"
+  engine_version = 15.3
+
+  vpc_id                 = var.vpc_id
+  subnets                = var.subnets
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  instance_class = var.instance_class
+  instances = {
+    one = {}
+  }
+
+  autoscaling_enabled      = true
+  autoscaling_min_capacity = var.autoscaling_min_capacity
+  autoscaling_max_capacity = var.autoscaling_max_capacity
+
+  create_monitoring_role = false
+  create_security_group  = false
+
+  publicly_accessible = false
+
+  database_name       = var.database_name
+  master_username     = var.username
+  master_password     = var.password
+  port                = 5432
+  deletion_protection = true
+
+  enabled_cloudwatch_logs_exports = ["postgresql"]
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -2,7 +2,7 @@ module "rds" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "9.0.0"
 
-  name = "${var.env_namespace}-aurora-db"
+  name = "${var.namespace}-aurora-db"
 
   engine         = "aurora-postgresql"
   engine_version = 15.3

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,3 @@
+output "db_endpoint" {
+  value = module.rds.cluster_endpoint
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -23,18 +23,6 @@ variable "instance_class" {
   type        = string
 }
 
-variable "autoscaling_min_capacity" {
-  description = "The minimum number of RDS instances"
-  type        = number
-  default     = 0
-}
-
-variable "autoscaling_max_capacity" {
-  description = "The maximum number of RDS instances"
-  type        = number
-  default     = 0
-}
-
 variable "database_name" {
   description = "The name of the database to create"
   type        = string
@@ -48,4 +36,5 @@ variable "username" {
 variable "password" {
   description = "RDS password. Some special chars might result in a wrong encoding of the DATABASE_URL"
   type        = string
+  sensitive   = true
 }

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -18,11 +18,6 @@ variable "vpc_security_group_ids" {
   type        = list(string)
 }
 
-variable "instance_class" {
-  description = "The RDS instance type to use, e.g. `db.t3.medium`"
-  type        = string
-}
-
 variable "database_name" {
   description = "The name of the database to create"
   type        = string

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,4 +1,4 @@
-variable "env_namespace" {
+variable "namespace" {
   description = "The namespace of the environment, e.g. `acme-web-staging`"
   type        = string
 }

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,51 @@
+variable "env_namespace" {
+  description = "The namespace of the environment, e.g. `acme-web-staging`"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "subnets" {
+  description = "A list of subnet IDs to be used by the RDS cluster"
+  type        = list(string)
+}
+
+variable "vpc_security_group_ids" {
+  description = "List of VPC security groups to associate"
+  type        = list(string)
+}
+
+variable "instance_class" {
+  description = "The RDS instance type to use, e.g. `db.t3.medium`"
+  type        = string
+}
+
+variable "autoscaling_min_capacity" {
+  description = "The minimum number of RDS instances"
+  type        = number
+  default     = 0
+}
+
+variable "autoscaling_max_capacity" {
+  description = "The maximum number of RDS instances"
+  type        = number
+  default     = 0
+}
+
+variable "database_name" {
+  description = "The name of the database to create"
+  type        = string
+}
+
+variable "username" {
+  description = "The DB master username: 1–16 alphanumeric characters and underscores, first character must be a letter, can't be a word reserved by the database engine"
+  type        = string
+}
+
+variable "password" {
+  description = "RDS password. Some special chars might result in a wrong encoding of the DATABASE_URL"
+  type        = string
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -1,0 +1,9 @@
+resource "aws_security_group" "rds" {
+  name        = "${var.namespace}-rds"
+  description = "RDS security group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.namespace}-rds-sg"
+  }
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -1,0 +1,4 @@
+output "rds_security_groups_ids" {
+  description = "List of RDS security group IDs"
+  value       = [aws_security_group.rds.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -1,0 +1,9 @@
+variable "namespace" {
+  description = "The namespace of the environment for the security groups, used as the prefix for the VPC security group names, e.g. `acme-web-staging`"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}

--- a/modules/ssm/main.tf
+++ b/modules/ssm/main.tf
@@ -1,7 +1,7 @@
 resource "aws_ssm_parameter" "secret_parameters" {
   for_each = var.secrets
 
-  name  = "/${var.env_namespace}/${each.key}-${random_string.service_secret_random_suffix.result}"
+  name  = "/${var.namespace}/${each.key}-${random_string.service_secret_random_suffix.result}"
   type  = "String"
   value = each.value
 }

--- a/modules/ssm/variables.tf
+++ b/modules/ssm/variables.tf
@@ -1,4 +1,4 @@
-variable "env_namespace" {
+variable "namespace" {
   description = "The namespace of the environment, e.g. `acme-web-staging`"
   type        = string
 }

--- a/shared/variables.tf
+++ b/shared/variables.tf
@@ -19,18 +19,3 @@ variable "aws_secret_key" {
   type        = string
   sensitive   = true
 }
-
-variable "iam_admin_emails" {
-  description = "List of IAM admin emails"
-  type        = list(string)
-}
-
-variable "iam_developer_emails" {
-  description = "List of IAM developer emails"
-  type        = list(string)
-}
-
-variable "iam_bot_emails" {
-  description = "List of IAM bot emails"
-  type        = list(string)
-}

--- a/shared/variables.tf
+++ b/shared/variables.tf
@@ -19,3 +19,18 @@ variable "aws_secret_key" {
   type        = string
   sensitive   = true
 }
+
+variable "iam_admin_emails" {
+  description = "List of IAM admin emails"
+  type        = list(string)
+}
+
+variable "iam_developer_emails" {
+  description = "List of IAM developer emails"
+  type        = list(string)
+}
+
+variable "iam_bot_emails" {
+  description = "List of IAM bot emails"
+  type        = list(string)
+}


### PR DESCRIPTION
- Close #11 

## What happened 👀

Integrate AWS RDS

## Insight 📝

- Using `terraform-aws-modules/rds-aurora/aws` module for integration
- Using PostgreSQL engine
- Adding `security group` for `RDS` module
- Updating `namespace` to be hyphen style `devops_ic` -> `devops-ic` since the rds cluster doesn't accept dash character

## Proof Of Work 📹

Security group created
![image](https://github.com/nvminhtue/tyson_devops_ic/assets/42540264/97f80ee6-5008-471c-9a3a-4abf5db23d72)


RDS created 
![image](https://github.com/nvminhtue/tyson_devops_ic/assets/42540264/9b0876be-d478-4d7e-a776-ea7c62e644d7)


RDS cluster created
![image](https://github.com/nvminhtue/tyson_devops_ic/assets/42540264/37cc4c74-01b4-4099-9f02-18b77d39afd9)

