### PR TITLE
[gh-12] Integrate ElastiCache

### DIFF
--- a/core/main.tf
+++ b/core/main.tf
@@ -102,3 +102,11 @@ module "ecs" {
   secrets_variables     = module.ssm.secrets_variables
   secrets_arns          = module.ssm.secret_arns
 }
+
+module "elasticache" {
+  source = "../modules/elasticache"
+
+  namespace          = local.namespace
+  subnets_ids        = module.vpc.private_subnets
+  security_group_ids = module.security_group.elasticache_security_groups_ids
+}

--- a/modules/elasticache/locals.tf
+++ b/modules/elasticache/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  engine               = "redis"
+  engine_version       = "6.x"
+  parameter_group_name = "default.redis6.x"
+  node_type            = "cache.t3.micro"
+  num_cache_clusters   = 1
+}

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -1,0 +1,21 @@
+resource "aws_elasticache_subnet_group" "this" {
+  name       = "${var.namespace}-subnet-group"
+  subnet_ids = var.subnets_ids
+}
+
+resource "aws_elasticache_replication_group" "this" {
+  replication_group_id = "${var.namespace}-replication-group"
+
+  engine         = local.engine
+  engine_version = local.engine_version
+  node_type      = local.node_type
+
+  // Redis Cluster mode disabled
+  num_cache_clusters         = local.num_cache_clusters
+  parameter_group_name       = local.parameter_group_name
+  automatic_failover_enabled = false
+  at_rest_encryption_enabled = false
+
+  subnet_group_name  = aws_elasticache_subnet_group.this.name
+  security_group_ids = var.security_group_ids
+}

--- a/modules/elasticache/outputs.tf
+++ b/modules/elasticache/outputs.tf
@@ -1,0 +1,4 @@
+output "redis_primary_endpoint" {
+  description = "Primary endpoint of the Redis cluster"
+  value       = aws_elasticache_replication_group.this.primary_endpoint_address
+}

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -1,0 +1,14 @@
+variable "namespace" {
+  description = "The namespace of the environment, e.g. `acme-web-staging`"
+  type        = string
+}
+
+variable "subnets_ids" {
+  description = "List of subnet IDs"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs"
+  type        = list(string)
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -70,3 +70,23 @@ resource "aws_security_group_rule" "ecs_fargate_egress_anywhere" {
   cidr_blocks = ["0.0.0.0/0"]
   description = "From ECS Fargate to anywhere"
 }
+
+resource "aws_security_group" "elasticache" {
+  name        = "${var.namespace}-elasticache-sg"
+  description = "Elasticache security group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.namespace}-elasticache-sg"
+  }
+}
+
+resource "aws_security_group_rule" "elasticache_ingress_fargate" {
+  description              = "From ECS Fargate to Elasticache"
+  type                     = "ingress"
+  security_group_id        = aws_security_group.elasticache.id
+  protocol                 = "tcp"
+  from_port                = 6379
+  to_port                  = 6379
+  source_security_group_id = aws_security_group.ecs_fargate.id
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -7,3 +7,8 @@ output "alb_security_groups_ids" {
   description = "List of ALB security group IDs"
   value       = [aws_security_group.alb.id]
 }
+
+output "elasticache_security_groups_ids" {
+  description = "List of Elasticache security group IDs"
+  value       = [aws_security_group.elasticache.id]
+}


### PR DESCRIPTION
- Close #12 

## What happened 👀

Integrate ElastiCache service

## Insight 📝

- Use the ElastiCache Cluster mode disabled due to the small scope of the project.
- Use `cache.t3.micro` as it's free

## Proof Of Work 📹

ElastiCache is created
![image](https://github.com/nvminhtue/tyson_devops_ic/assets/42540264/7d91879e-26ef-4289-b2c8-261188da44a6)
<img width="299" alt="image" src="https://github.com/nvminhtue/tyson_devops_ic/assets/42540264/f5edf2b3-277b-402d-8632-65a6e71b6e46">

Security group is configurated
<img width="303" alt="image" src="https://github.com/nvminhtue/tyson_devops_ic/assets/42540264/b2f2dab2-1bbb-423f-b74b-141f4ff23201">

